### PR TITLE
Fix setup step "artisan migrate" resulting in sql error

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -15,8 +15,8 @@ class CreateUsersTable extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->uuid('id')->primary();
-            $table->string('username')->unique();
-            $table->string('barcode')->unique()->nullable();
+            $table->string('username', 150)->unique();
+            $table->string('barcode', 30)->unique()->nullable();
             $table->string('email')->nullable();
             $table->string('phone')->nullable();
             $table->boolean('is_healthy')->default(false);

--- a/database/migrations/2020_06_07_220051_create_resources_table.php
+++ b/database/migrations/2020_06_07_220051_create_resources_table.php
@@ -17,7 +17,7 @@ class CreateResourcesTable extends Migration
         Schema::create('resources', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->bigIncrements('id');
-            $table->string('name')->unique();
+            $table->string('name', 150)->unique();
             $table->string('short_name')->nullable();
             $table->integer('capacity')->default(0);
             $table->string('color')->nullable();


### PR DESCRIPTION
Hi,
I had a minor problem with the setup :)

**Description**
Command `php artisan migrate` fails for a fresh database (utf8mb4) like displayed at the end ("specified key was too long").

**Reasoning**
It seems that the definition in files likes \database\migrations\2014_10_12_000000_create_users_table.php should specify fields with unique indexes either with explicit sizes or some default setting has to be changed.

**Mitigation/fix**
Set explicit sizes for unique columns (like `$table->string('username')->unique();` to `$table->string('username', 30)->unique();`).

**Error example**
```php
PHP Warning:  PHP Startup: Unable to load dynamic library 'mysqli' (tried: /usr/lib/php/20190902/mysqli (/usr/lib/php/20190902/mysqli: cannot open shared object file: No such file or directory), /usr/lib/php/20190902/mysqli.so (/usr/lib/php/20190902/mysqli.so: undefined symbol: mysqlnd_global_stats)) in Unknown on line 0
PHP Warning:  Module 'curl' already loaded in Unknown on line 0
PHP Warning:  Module 'mbstring' already loaded in Unknown on line 0
PHP Warning:  Module 'soap' already loaded in Unknown on line 0
Migration table created successfully.
Migrating: 2014_10_12_000000_create_users_table

   Illuminate\Database\QueryException

  SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 767 bytes (SQL: alter table `users` add unique `users_username_unique`(`username`))

  at vendor/laravel/framework/src/Illuminate/Database/Connection.php:671
    667|         // If an exception occurs when attempting to run a query, we'll format the error
    668|         // message to include the bindings with SQL, which will make this exception a
    669|         // lot more helpful to the developer instead of just the database's errors.
    670|         catch (Exception $e) {
  > 671|             throw new QueryException(
    672|                 $query, $this->prepareBindings($bindings), $e
    673|             );
    674|         }
    675|

      +9 vendor frames
  10  database/migrations/2014_10_12_000000_create_users_table.php:26
      Illuminate\Support\Facades\Facade::__callStatic()

      +22 vendor frames
  33  artisan:37
      Illuminate\Foundation\Console\Kernel::handle()

   Whoops\Exception\ErrorException

  Module 'soap' already loaded

  at Unknown:0
    1|

      +1 vendor frames
  2   [internal]:0
      Whoops\Run::handleShutdown()
```